### PR TITLE
replace Vec::from_raw_parts with ptr::write_bytes

### DIFF
--- a/src/wasm/main.rs
+++ b/src/wasm/main.rs
@@ -57,9 +57,13 @@ pub fn alloc(size: usize) -> *mut c_void {
 
 #[no_mangle]
 pub fn dealloc(ptr: *mut c_void, size: usize) {
-    unsafe {
-        let _buf = Vec::from_raw_parts(ptr, 0, size);
+    // Clear memory to zero for security purposes (optional).
+    if !ptr.is_null() && size > 0 {
+        unsafe {
+            std::ptr::write_bytes(ptr, 0, size);
+        }
     }
+    // The memory deallocation is deferred to the caller (e.g., via `free`).
 }
 
 #[no_mangle]


### PR DESCRIPTION
fix https://github.com/flaneur2020/pua-lang/issues/76

**Key changes:**
1. Removed Vec::from_raw_parts to avoid taking ownership of the pointer.
2. Added optional memory clearing using std::ptr::write_bytes for security purposes.
3. Ensured memory deallocation responsibility is left to the caller, preventing double free issues.

compile success when run `cargo build`